### PR TITLE
Add `plans/rpmlint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ You can alter the inputs of this plan through environment variables.
   - [ ] `/rpminspect`
   - [ ] `/rpmdeplint`
   - [ ] `/installability`
+- Other plans
+  - [`/plans/rpmlint`](plans/rpmlint)

--- a/plans/rpmlint/README.md
+++ b/plans/rpmlint/README.md
@@ -1,0 +1,38 @@
+# Rpmlint
+
+<!-- SPHINX-START -->
+
+Run [rpmlint] on the current Copr project or Koji build
+
+## Synopsis
+
+```yaml
+plans:
+  import:
+    url: https://github.com/packit/tmt-plans
+    ref: main
+    name: /plans/rpmlint
+```
+
+## Options
+
+None so far
+
+## Examples
+
+- Rpmlint the upstream packit project
+  ```yaml
+  plans:
+    import:
+      url: https://github.com/packit/tmt-plans
+      ref: main
+      name: /plans/rpmlint
+  ```
+
+## See Also
+
+- [rpmlint]
+
+<!-- SPHINX-END -->
+
+[rpmlint]: https://github.com/rpm-software-management/rpmlint

--- a/plans/rpmlint/README.md
+++ b/plans/rpmlint/README.md
@@ -14,9 +14,26 @@ plans:
     name: /plans/rpmlint
 ```
 
+## Description
+
+This plan simply runs the command
+
+```console
+$ rpmlint ./*.rpm
+```
+
+Currently, there is no support to pass in additional `.rpmlintrc` due to limitations of the [`tmt`][tmt-import]
+interface. The `rpm` and `srpm` artifacts are taken from the testing-farm artifacts
+
+:::note
+
+The rpmlint of the `.spec` file is handled automatically when running `rpmlint` against a `srpm`.
+
+:::
+
 ## Options
 
-None so far
+No options available
 
 ## Examples
 
@@ -36,3 +53,4 @@ None so far
 <!-- SPHINX-END -->
 
 [rpmlint]: https://github.com/rpm-software-management/rpmlint
+[tmt-import]: https://tmt.readthedocs.io/en/stable/spec/plans.html#import-plans

--- a/plans/rpmlint/main.fmf
+++ b/plans/rpmlint/main.fmf
@@ -9,6 +9,10 @@ prepare:
     package:
       - rpmlint
       - tree
+  - name: Copy rpmlint toml configuration file
+    how: shell
+    script: cp plans/rpmlint/packit.toml $TMT_PLAN_DATA/packit.toml
+  # TODO: How to get the .rpmlintrc files?
 
 discover+:
   filter: "tag: rpmlint"

--- a/plans/rpmlint/main.fmf
+++ b/plans/rpmlint/main.fmf
@@ -1,0 +1,14 @@
+summary: Run rpmlint on all rpms and spec file
+
+description: |
+  Equivalent to zuul job running rpmlint
+
+prepare:
+  - name: Get necessary packages
+    how: install
+    package:
+      - rpmlint
+      - tree
+
+discover+:
+  filter: "tag: rpmlint"

--- a/plans/rpmlint/packit.toml
+++ b/plans/rpmlint/packit.toml
@@ -1,0 +1,4 @@
+Filters = [
+    # Avoid copr signing issues
+    "unknown-key",
+]

--- a/tests/rpmlint/main.fmf
+++ b/tests/rpmlint/main.fmf
@@ -1,0 +1,4 @@
+summary: Run rpmlint
+tag: rpmlint
+
+test+: rpmlint.sh

--- a/tests/rpmlint/rpmlint.sh
+++ b/tests/rpmlint/rpmlint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+	rlPhaseStartSetup
+		rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+		rlRun "pushd $tmp"
+		rlRun "set -o pipefail"
+	rlPhaseEnd
+
+	rlPhaseStartTest
+		rlRun "rpm2cpio /var/share/test-artifacts/*.src.rpm | cpio -civ '*.spec'" 0 "Extract spec file from srpm"
+		rlRun "cp ./*.spec $TMT_TEST_DATA/" 0 "Expose spec file"
+		# The spec rpmlint is already executed from the srpm
+		rlRun "rpmlint -c $TMT_PLAN_DATA/packit.toml /var/share/test-artifacts/*.rpm" 0 "Run rpmlint"
+	rlPhaseEnd
+
+	rlPhaseStartCleanup
+		rlRun "popd"
+		rlRun "rm -r $tmp" 0 "Remove tmp directory"
+	rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION
TODO:
- [ ] How to get the `.rpmlintrc` files from upstream? (Will look into a next PR)
- [x] ~~Where is the `.spec` file?~~ It is available within the srpm
- [x] ~~Where are the imported plans files located?~~ Just use relative path to the imported plan