### PR TITLE
fix: rpminspect report

### DIFF
--- a/plans/rpminspect/README.md
+++ b/plans/rpminspect/README.md
@@ -61,6 +61,21 @@ See `rpminspect -l` for a list of available tests.
 
 See `rpminspect -l` for a list of available tests.
 
+`RPMINSPECT_THRESHOLD` \[Default: `BAD`\]
+
+: Set the maximum result status that makes the rpminspect test fail
+
+One of \[`OK`, `INFO`, `VERIFY`, `BAD` \]
+
+The default will treat each check status as `pass`, `info`, `warn`, `fail` respectively. Use this variable to mark the
+overall `pass`/`fail` of the test.
+
+`RPMINSPECT_SUPPRESS`
+
+: Set the minimum result status that will be reported
+
+One of \[`OK`, `INFO`, `VERIFY`, `BAD` \]
+
 `RPMINPSECT_ARCHES`
 
 : Run inspection only on the specified architecture packages

--- a/plans/rpminspect/main.fmf
+++ b/plans/rpminspect/main.fmf
@@ -15,6 +15,7 @@ prepare:
       - koji
       - clamav-freshclam
       - tree
+      - jq
   - name: Get other files from repo
     how: shell
     script: >

--- a/tests/rpminspect/rpminspect.sh
+++ b/tests/rpminspect/rpminspect.sh
@@ -98,7 +98,8 @@ else
 	if (( bad_results > 0 )); then
 		result=fail
 	elif (( verify_results > 0 )); then
-		result=warn
+		# TODO: Switch result to warn when testing-farm supports it
+		result=info
 	elif (( info_results > 0 )); then
 		result=info
 	else


### PR DESCRIPTION
Refined the reporting of rpminspect so that the plan does not fail on `VERIFY` results

Depends on: #15 