### PR TITLE
fedora-review: Allow to be run in testing-farm multihost pipeline

### DIFF
--- a/plans/fedora-review/main.fmf
+++ b/plans/fedora-review/main.fmf
@@ -12,6 +12,12 @@ description: |
 provision:
   how: virtual
   image: fedora
+adjust+:
+  - when: initiator == packit, fedora-ci
+    because: testing-farm does not know how to map virtual to artemis provision
+    provision:
+      how: artemis
+      image: Fedora-latest
 
 discover:
   how: fmf


### PR DESCRIPTION
In principle this is a testing-farm bug that it should try to translate those, but I guess it doesn't hurt to be explicit here for now.
